### PR TITLE
canonical: json: decode: add missing format string to Errorf

### DIFF
--- a/canonical/json/decode.go
+++ b/canonical/json/decode.go
@@ -600,7 +600,7 @@ func (d *decodeState) object(v reflect.Value) {
 			case string:
 				d.literalStore([]byte(qv), subv, true)
 			default:
-				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal unquoted value into %v", item, v.Type()))
+				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal unquoted value %q into %v", item, v.Type()))
 			}
 		} else {
 			d.value(subv)


### PR DESCRIPTION
As found in:

```
vendor/src/github.com/jfrazelle/go/canonical/json/decode.go:603: wrong
number of args for format in Errorf call: 1 needed but 2 args
exit status 1
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
